### PR TITLE
make sure node-gyp is ready

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -89,7 +89,9 @@ jobs:
 
       - name: Fix Windows x86 sqlite3 binding
         if: steps.yarn-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows') && matrix.target == 'x86'
-        run: yarn upgrade sqlite3
+        run: |
+          yarn global add --network-timeout 600000 node-gyp node-pre-gyp node-gyp-build node-gyp-build-optional-packages
+          yarn upgrade sqlite3
         # Prebuilt binding is for x64. We must build from source for x86 target.
         # See:
         # https://stackoverflow.com/questions/72553650/how-to-get-node-sqlite3-working-on-mac-m1


### PR DESCRIPTION
A change in how node-gyp is handled in grist-core needed to be propagated for Windows x86.