### PR TITLE
Fix unpack-error-handling in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -71,7 +71,9 @@ function fetch_python {
 }
 
 function unpack_python {
-  cd core && tar xfz cpython.tar.gz && cd ..
+  cd core
+  tar xfz cpython.tar.gz
+  cd ..
 }
 
 function fetch_msapi {
@@ -83,9 +85,15 @@ function fetch_msapi {
 
 function unpack_msapi {
   if [[ "$arch" = "x86" ]]; then
-    cd core && unzip api.zip && cp api-ms-win-core-path-blender/x86/*.dll python/ && cd ..
+    cd core
+    unzip api.zip
+    cp api-ms-win-core-path-blender/x86/*.dll python/
+    cd ..
   elif [[ "$arch" = "x64" ]]; then
-    cd core && unzip api.zip && cp api-ms-win-core-path-blender/x64/*.dll python/ && cd ..
+    cd core
+    unzip api.zip
+    cp api-ms-win-core-path-blender/x64/*.dll python/
+    cd ..
   else
     not_implemented
   fi


### PR DESCRIPTION
Currently, `scripts/setup.sh` attempts to have error-handling in the event of failure to install a self-contained copy of Python, with the fallback of just using the system `python3`. However, this error-handling doesn't work correctly, due to a quirk of how `unpack_python` and `unpack_msapi` are written: `cd core && [unpack command(s)] && cd ..`, all in one line, with the effect that if the unpack errors then the subseqent `cd ..` never runs, which leads in turn to a failure in the still-further-subsequent `cd core/sandbox/pyodide` line (because the working directory is already `core`) and as such a failure of the overall setup script.

This PR, then, breaks those unpack functions' commands up to each run on separate lines, so that even if an unpack fails the subsequent `cd ..` line will still be run and the overall setup can still proceed.