### PR TITLE
Rename pyodide worker path

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,8 +186,8 @@
       "!core/cpython.tar.gz",
       "!core/python",
       "!core/documentation",
-      "!core/sandbox/pyodide/_build/worker/node_modules/deno/deno",
-      "!core/sandbox/pyodide/_build/worker/node_modules/deno/deno.exe",
+      "!core/sandbox/pyodide/worker/node_modules/deno/deno",
+      "!core/sandbox/pyodide/worker/node_modules/deno/deno.exe",
       "!**/test_*.py"
     ],
     "directories": {


### PR DESCRIPTION
related to https://github.com/gristlabs/grist-core/pull/2297

This is the only change I could find to be related.
Note that I did not really test this - it looks trivial, and I will test this as part of #105 for the next release of grist-desktop.
Also note that this change does affect all builds, not only the Flatpak.

Please let me know if you think more testing is necessary.

n.b. to be merged only when `core` is updated