### PR TITLE
Fixes Windows build when in a Cygwin environment

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,7 +51,7 @@ fi
 if [[ "$os" = "linux-musl"* ]]; then
   os="linux"
 fi
-if [[ "$os" = "msys"* ]]; then
+if [[ "$os" = "msys"* || "$os" = "cygwin"* ]]; then
   os="windows"
 fi
 if [[ "$os" = "darwin"* ]]; then
@@ -122,6 +122,8 @@ function python_for_windows {
   unpack_python
   unpack_msapi
 }
+
+alias
 
 function python_for_mac {
   if [[ "$arch" = "x64" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -123,8 +123,6 @@ function python_for_windows {
   unpack_msapi
 }
 
-alias
-
 function python_for_mac {
   if [[ "$arch" = "x64" ]]; then
     fetch_python ${PYTHON_BUILD_DATE}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD_DATE}-x86_64-apple-darwin-install_only.tar.gz


### PR DESCRIPTION
CI seems to have recently started reporting `cygwin` as the OSTYPE when running `setup.sh`, and failing as it then bypasses the Python installation logic (as it doesn't know how to handle Cygwin).

This makes it treat cygwin as Windows, fetching the correct binary.