### PR TITLE
Move GRIST_USER_ROOT to appData

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,15 @@ to the default. Must be one of `pyodide`, `gvisor`, `macSandboxExec` and
 Grist Desktop works. For the time being, Grist Desktop works by launching a Grist server
 in the background. These variables can configure where the Grist server should store its files.
 By default, `GRIST_INST_DIR` is set to `getPath("userData")` defined by Electron;
-`GRIST_DATA_DIR` is set to `getPath("documents")`; `GRIST_USER_ROOT` is set to `.grist`
-in your home directory. `TYPEORM_DATABASE` is set to `landing.db` under
-`getPath("appData")`. If you change them, make sure to move existing data accordingly.
-See [grist-core documentation](https://github.com/gristlabs/grist-core) for details.
-You might want to store your Grist documents somewhere else and have a clean "Documents"
-folder. In this case, set `GRIST_DATA_DIR` to your desired location and move all `.grist`
-files there.
+`GRIST_DATA_DIR` is set to `getPath("documents")`;
+`GRIST_USER_ROOT` is set to `getPath("userData")` (unless `~/.grist/plugins` exists,
+then `~/.grist` is used, for backwards compatibility);
+`TYPEORM_DATABASE` is set to `landing.db` under `getPath("appData")`.
+If you change them, make sure to move existing data accordingly.  See [grist-core
+documentation](https://github.com/gristlabs/grist-core) for details.  You might
+want to store your Grist documents somewhere else and have a clean "Documents"
+folder. In this case, set `GRIST_DATA_DIR` to your desired location and move
+all `.grist` files there.
 
 ### Note on using Grist Desktop as a server
 

--- a/README.md
+++ b/README.md
@@ -147,14 +147,12 @@ be one of `true` or `false`. Default: `true`
 to the default. Must be one of `pyodide`, `gvisor`, `macSandboxExec` and
 `unsandboxed`. See this [note](#note-on-sandboxing) for more info. Default: `pyodide`
 
-**`GRIST_INST_DIR`**, **`GRIST_DATA_DIR`**, **`GRIST_USER_ROOT`** and
-**`TYPEORM_DATABASE`**: These are a bit technical and require some understanding of how
-Grist Desktop works. For the time being, Grist Desktop works by launching a Grist server
-in the background. These variables can configure where the Grist server should store its files.
-By default, `GRIST_INST_DIR` is set to `getPath("userData")` defined by Electron;
+**`GRIST_INST_DIR`**, **`GRIST_DATA_DIR`** and **`TYPEORM_DATABASE`**: These are a bit
+technical and require some understanding of how Grist Desktop works. For the time being,
+Grist Desktop works by launching a Grist server in the background. These variables can
+configure where the Grist server should store its files. By default,
+`GRIST_INST_DIR` is set to `getPath("userData")` defined by Electron;
 `GRIST_DATA_DIR` is set to `getPath("documents")`;
-`GRIST_USER_ROOT` is set to `getPath("userData")` (unless `~/.grist/plugins` exists,
-then `~/.grist` is used, for backwards compatibility);
 `TYPEORM_DATABASE` is set to `landing.db` under `getPath("appData")`.
 If you change them, make sure to move existing data accordingly.  See [grist-core
 documentation](https://github.com/gristlabs/grist-core) for details.  You might
@@ -162,10 +160,17 @@ want to store your Grist documents somewhere else and have a clean "Documents"
 folder. In this case, set `GRIST_DATA_DIR` to your desired location and move
 all `.grist` files there.
 
+**`GRIST_USER_ROOT`**: for installing local plugins. By default, this is set to
+`getPath("userData")`, which would be `~/.config/Grist Desktop` on Linux. Note that if
+`~/.grist/plugins` exists (and not `~/.config/Grist Desktop/plugins`), `~/.grist` is
+used instead, for backwards compatibility.
+For Windows the default location is `C:\users\AppData\Grist Desktop`, and for the
+Flatpak from Flathub `~/.var/app/com.getgrist.grist/config/Grist Desktop`.
+
 ### Note on using Grist Desktop as a server
 
 If you are sure you are in a trusted environment, you can use the app as a
-quick way to set up a simple Grist server, but be aware that data is being 
+quick way to set up a simple Grist server, but be aware that data is being
 sent using plain http and not encrypted https, so network traffic could be
 readable in transit. And there is no login mechanism built in.
 

--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -24,6 +24,16 @@ function validateOrFallback(envKey: string, validator: (value: string) => boolea
   }
 }
 
+function findUserRoot(): string {
+  // GRIST_USER_ROOT used to be ~/.grist but was moved to appData.
+  // Prefer the new location, but use the old if it has a plugins folder.
+  // Note that it is only used for plugins, so check that folder.
+  const userRoot = electron.app.getPath("userData");
+  const oldUserRoot = path.join(electron.app.getPath("home"), ".grist");
+  if (fse.existsSync(path.join(userRoot, "plugins"))) return userRoot;
+  if (fse.existsSync(path.join(oldUserRoot, "plugins"))) return oldUserRoot;
+  return userRoot;
+}
 
 export async function loadConfig() {
   dotenv.config();
@@ -89,7 +99,7 @@ export async function loadConfig() {
   validateOrFallback(
     "GRIST_USER_ROOT",
     NO_VALIDATION,
-    path.join(electron.app.getPath("home"), ".grist")
+    findUserRoot()
   );
   validateOrFallback(
     "PYTHON_VERSION_ON_CREATION",

--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -30,8 +30,12 @@ function findUserRoot(): string {
   // Note that it is only used for plugins, so check that folder.
   const userRoot = electron.app.getPath("userData");
   const oldUserRoot = path.join(electron.app.getPath("home"), ".grist");
-  if (fse.existsSync(path.join(userRoot, "plugins"))) return userRoot;
-  if (fse.existsSync(path.join(oldUserRoot, "plugins"))) return oldUserRoot;
+  if (fse.existsSync(path.join(userRoot, "plugins"))) {
+    return userRoot;
+  }
+  if (fse.existsSync(path.join(oldUserRoot, "plugins"))) {
+    return oldUserRoot;
+  }
   return userRoot;
 }
 


### PR DESCRIPTION
Implements what was discussed in https://github.com/gristlabs/grist-desktop/pull/110#issuecomment-4455469971.

I've chosen to check the `plugins` folder, as that is the only entry we really expect in there.

Note that the path to add plugins, will become `~/.config/Grist Desktop/plugins` (from reading [`app.getPath()` documentation](https://www.electronjs.org/docs/latest/api/app#appgetpathname)), or `~/.var/app/com.getgrist.grist/config/Grist Desktop/plugins` for the Flathub Flatpak.