### PR TITLE
Run some of Grist's browser tests against the desktop app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,9 @@ jobs:
 
       - name: Test
         run: yarn run test
+
+      - name: Build core browser tests
+        run: yarn run build:tests
+
+      - name: Run core browser tests against the desktop app
+        run: yarn run test:electron:upstream

--- a/ext/app/electron/GristApp.ts
+++ b/ext/app/electron/GristApp.ts
@@ -112,6 +112,10 @@ export class GristApp {
     // Wait for both electron and the Grist server to fully initialize.
     await Promise.all([mergedServer.run(), electron.app.whenReady()]);
 
+    if (process.env.GRIST_TESTING_SOCKET) {
+      await this.flexServer.addTestingHooks();
+    }
+
     const serverMethods = this.flexServer.electronServerMethods;
 
     const recentItems = new RecentItems({

--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -140,7 +140,7 @@ export async function loadConfig() {
   process.env.GRIST_ORG_IN_PATH = "true";
   process.env.GRIST_HIDE_UI_ELEMENTS = "helpCenter,billing,templates,multiSite,multiAccounts,tutorials";
   process.env.GRIST_CONTACT_SUPPORT_URL = packageJson.repository + "/issues";
-  if (process.env.GRIST_DESKTOP_AUTH !== "mixed") {
+  if (process.env.GRIST_DESKTOP_AUTH !== "mixed" && process.env.GRIST_FORCE_LOGIN === undefined) {
     process.env.GRIST_FORCE_LOGIN = "true";
   }
 

--- a/ext/app/electron/main.ts
+++ b/ext/app/electron/main.ts
@@ -22,8 +22,10 @@ import * as packageJson from "ext/desktop.package.json";
 import { GristApp } from "app/electron/GristApp";
 import { loadConfig } from "app/electron/config";
 import { setupLogging } from "./logging";
+import { IS_TEST_MODE, filterArgvForCommander, installDialogStubs } from "app/electron/testMode";
 
 applyPatch();
+installDialogStubs();
 
 // Mimic the behavior of a packaged app, where argv will not include "electron" and its arguments.
 // Example:
@@ -85,11 +87,16 @@ electronProgram
     initialFileToOpen = docPath ?? null;
   });
 
+if (IS_TEST_MODE) {
+  electronProgram.allowUnknownOption().allowExcessArguments();
+}
+
 async function main() {
   // Commander.js has "node" and "electron" modes, but they don't handle the quirks above well enough.
   // Thus, we manually handle CLI arguments Commander doesn't need to see.
   // Here, slice to ignore argv[0].
-  await electronProgram.parseAsync(process.argv.slice(1), { from: "user" });
+  const argsForCommander = filterArgvForCommander(process.argv.slice(1));
+  await electronProgram.parseAsync(argsForCommander, { from: "user" });
   if (exitCode) {
     electron.app.exit(exitCode);
   } else if (exitCode === 0) {

--- a/ext/app/electron/testMode.ts
+++ b/ext/app/electron/testMode.ts
@@ -1,0 +1,36 @@
+// Helpers active when GRIST_DESKTOP_TEST_MODE is set: tolerate Chromium
+// switches in argv, and stub native dialogs that would block the renderer.
+
+import * as electron from "electron";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { isAffirmative } from "app/common/gutil";
+import log from "app/server/lib/log";
+
+export const IS_TEST_MODE = isAffirmative(process.env.GRIST_DESKTOP_TEST_MODE);
+
+const CHROMIUM_TRAILING_URL = "data:,";
+
+export function installDialogStubs() {
+  if (!IS_TEST_MODE) { return; }
+  const dialogStubDir = fs.mkdtempSync(path.join(os.tmpdir(), "grist-test-dialog-"));
+  electron.app.on("will-quit", () => fs.rmSync(dialogStubDir, {recursive: true, force: true}));
+  let counter = 0;
+  electron.dialog.showSaveDialog = (async (...args: any[]) => {
+    // Caller may pass (options) or (browserWindow, options).
+    const opts = (args[0] && 'filters' in args[0]) ? args[0] : args[1];
+    const ext = opts?.filters?.[0]?.extensions?.[0] || "grist";
+    return {canceled: false, filePath: path.join(dialogStubDir, `test-${++counter}.${ext}`)};
+  }) as typeof electron.dialog.showSaveDialog;
+  electron.dialog.showOpenDialog = (async () =>
+    ({canceled: true, filePaths: []})) as typeof electron.dialog.showOpenDialog;
+  electron.dialog.showErrorBox = ((title: string, content: string) => {
+    log.warn(`(stubbed dialog) ${title}: ${content}`);
+  }) as typeof electron.dialog.showErrorBox;
+}
+
+export function filterArgvForCommander(argv: string[]): string[] {
+  if (!IS_TEST_MODE) { return argv; }
+  return argv.filter(a => !a.startsWith("-") && a !== CHROMIUM_TRAILING_URL);
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/trusted-types": "2.0.7",
+    "chromedriver": "146",
     "fast-xml-parser": "^5.7.3",
     "resolve-tspaths": "^0.8.19",
     "typescript": "4.7.4"
@@ -31,6 +32,7 @@
   "scripts": {
     "setup": "./scripts/setup.sh && cd core && yarn run install:python",
     "build": "cd core && yarn run build:prod && resolve-tspaths -p tsconfig-ext.json",
+    "build:tests": "cd core && ./node_modules/.bin/tsc --build test/tsconfig.json && resolve-tspaths -p test/tsconfig.json",
     "paths": "cd core && resolve-tspaths -p tsconfig-ext.json",
     "electron:preview": "electron --trace-warnings core/_build/ext/app/electron/main.js",
     "electron:dir": "electron-builder build --linux --dir",
@@ -38,12 +40,13 @@
     "electron:linux:appimage": "electron-builder build --linux appimage",
     "electron:ci": "./scripts/ci.sh",
     "electron": "electron-builder build --publish never",
-    "test": "./scripts/smoke-test.sh"
+    "test": "./scripts/smoke-test.sh && yarn run test:electron",
+    "test:electron": "./scripts/test-electron.js",
+    "test:electron:upstream": "./scripts/test-electron.js --upstream"
   },
   "resolutions": {
     "jquery": "3.5.0",
-    "ts-interface-checker": "1.0.2",
-    "chromedriver": "110.0.0"
+    "ts-interface-checker": "1.0.2"
   },
   "build": {
     "appId": "com.getgrist.grist",

--- a/scripts/test-electron.js
+++ b/scripts/test-electron.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/*
+ * Cross-platform runner for the WebDriver-driven Electron test harness.
+ * Replaces the Linux-only test_electron.sh.
+ *
+ * Usage:
+ *   scripts/test-electron.js                    # local smoke
+ *   scripts/test-electron.js --upstream         # core deployment Smoke
+ *   scripts/test-electron.js --upstream Foo Bar # named upstream tests
+ *
+ * On Linux without a real display, wraps in xvfb-run and isolates D-Bus so
+ * native dialogs can't escape to the host. macOS and Windows runners have a
+ * display and run directly.
+ */
+
+const {spawn, spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const IS_LINUX = process.platform === 'linux';
+const HEADLESS = process.env.HEADLESS !== '0';
+
+// Upstream nbrowser suites known to pass cleanly against the desktop.
+// Smoke is excluded: it depends on cloud Grist's anonymous-fork-create UX,
+// which doesn't apply to desktop's file-backed docs.
+const DEFAULT_UPSTREAM_SUITES = [
+  'ActionLog', 'ChoiceList', 'ColumnTransform', 'CopyPasteLinked',
+  'DetailView', 'DuplicateDocument', 'FilteringBugs', 'LeftPanel',
+  'MultiColumn1', 'MultiColumn3', 'Pages', 'RowMenu', 'ToggleColumns',
+];
+
+function parseArgs(argv) {
+  let mode = 'local';
+  const rest = [...argv];
+  if (rest[0] === '--upstream') { mode = 'upstream'; rest.shift(); }
+  return {mode, names: rest};
+}
+
+function resolveTestFiles(mode, names) {
+  if (mode === 'local') {
+    if (names[0] === 'Probe') { return [path.join(ROOT, 'test/electron/Probe.test.js')]; }
+    return [path.join(ROOT, 'test/electron/Smoke.test.js')];
+  }
+  const targets = names.length > 0 ? names : DEFAULT_UPSTREAM_SUITES;
+  return targets.map(name => {
+    for (const dir of ['deployment', 'nbrowser']) {
+      const p = path.join(ROOT, 'core/_build/test', dir, `${name}.js`);
+      if (fs.existsSync(p)) { return p; }
+    }
+    throw new Error(`test not found: ${name} (not in deployment/ or nbrowser/)`);
+  });
+}
+
+function checkPrereqs() {
+  const mochaBin = path.join(ROOT, 'core/node_modules/.bin', process.platform === 'win32' ? 'mocha.cmd' : 'mocha');
+  if (!fs.existsSync(mochaBin)) {
+    throw new Error(`mocha not found at ${mochaBin}; run yarn install first`);
+  }
+  const appEntry = path.join(ROOT, 'core/_build/ext/app/electron/main.js');
+  if (!fs.existsSync(appEntry)) {
+    throw new Error('build output missing; run yarn build first');
+  }
+  return {mochaBin};
+}
+
+function buildEnv(mode) {
+  const sep = path.delimiter;
+  const nodePath = [
+    path.join(ROOT, 'core/_build/ext'),
+    path.join(ROOT, 'core/_build/stubs'),
+    path.join(ROOT, 'core/_build'),
+  ].join(sep);
+  return {
+    ...process.env,
+    NODE_PATH: nodePath,
+    SELENIUM_BROWSER: 'chrome',
+    MOCHA_WEBDRIVER_IGNORE_CHROME_VERSION: '1',
+    GRIST_LOG_LEVEL: process.env.GRIST_LOG_LEVEL || 'warn',
+    // Tells setup.js to do the extra setup the borrowed Grist suites need.
+    ...(mode === 'upstream' ? {GRIST_DESKTOP_TEST_UPSTREAM: '1'} : {}),
+  };
+}
+
+// On Linux + headless, re-exec ourselves under xvfb-run so the BrowserWindow
+// has a virtual display, and unset host session env so native dialogs (file
+// pickers, etc.) can't escape via xdg-desktop-portal.
+function maybeReexecUnderXvfb(argv) {
+  if (!IS_LINUX || !HEADLESS || process.env.XVFB_RUNNING === '1') { return false; }
+  const xvfb = spawnSync('command', ['-v', 'xvfb-run'], {shell: true});
+  if (xvfb.status !== 0) {
+    console.warn(`warning: xvfb-run not found; running against $DISPLAY=${process.env.DISPLAY || ''}`);
+    return false;
+  }
+  const env = {...process.env, XVFB_RUNNING: '1'};
+  for (const v of ['WAYLAND_DISPLAY', 'XDG_SESSION_TYPE', 'DBUS_SESSION_BUS_ADDRESS',
+                   'XDG_RUNTIME_DIR', 'XDG_CURRENT_DESKTOP', 'XDG_DATA_DIRS',
+                   'XDG_CONFIG_DIRS', 'GTK_USE_PORTAL']) { delete env[v]; }
+  const cmd = spawn('xvfb-run',
+    ['--auto-servernum', '--server-args=-screen 0 1920x1080x24',
+      process.execPath, __filename, ...argv],
+    {stdio: 'inherit', env});
+  cmd.on('exit', code => process.exit(code ?? 1));
+  return true;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (maybeReexecUnderXvfb(argv)) { return; }
+
+  const {mode, names} = parseArgs(argv);
+  const {mochaBin} = checkPrereqs();
+  const testFiles = resolveTestFiles(mode, names);
+
+  const args = [
+    '--reporter', 'spec',
+    '--slow', '10000',
+    '--require', path.join(ROOT, 'test/electron/setup.js'),
+    ...testFiles,
+  ];
+  const child = spawn(mochaBin, args, {stdio: 'inherit', cwd: ROOT, env: buildEnv(mode)});
+  child.on('exit', code => process.exit(code ?? 1));
+}
+
+try { main(); }
+catch (e) { console.error(String(e.message || e)); process.exit(1); }

--- a/test/electron/Probe.test.js
+++ b/test/electron/Probe.test.js
@@ -1,0 +1,22 @@
+const mw = require('mocha-webdriver');
+
+describe('Probe', function () {
+  this.timeout(60_000);
+  it('reports home page state', async function () {
+    const driver = mw.driver;
+    await driver.get('http://localhost:8585/');
+    await driver.sleep(2000);
+    console.log('url:    ', await driver.getCurrentUrl());
+    console.log('title:  ', await driver.getTitle());
+    const probe = await driver.executeScript(`
+      const has = sel => !!document.querySelector(sel);
+      return {
+        bodyStart: (document.body && document.body.innerText || '').slice(0, 300),
+        hasIntroCreate: has('.test-intro-create-doc'),
+        hasUserSignIn: has('.test-user-sign-in'),
+        cookies: document.cookie,
+      };
+    `);
+    console.log('probe:', JSON.stringify(probe, null, 2));
+  });
+});

--- a/test/electron/Smoke.test.js
+++ b/test/electron/Smoke.test.js
@@ -1,0 +1,24 @@
+const {assert} = require('chai');
+const mw = require('mocha-webdriver');
+
+const HOST = `http://localhost:${process.env.GRIST_PORT || 8585}`;
+
+describe('Smoke', function () {
+  this.timeout(60_000);
+
+  it('reaches the home page', async function () {
+    await mw.driver.get(HOST + '/');
+    await mw.driver.wait(async () => /Grist/.test(await mw.driver.getTitle()), 30_000);
+  });
+
+  it('exposes the Grist API to anonymous sessions', async function () {
+    const result = await mw.driver.executeAsyncScript(async function (cb) {
+      try {
+        const r = await fetch('/api/session/access/active', {credentials: 'include'});
+        cb({status: r.status, body: await r.text()});
+      } catch (e) { cb({error: String(e)}); }
+    });
+    assert.equal(result.status, 200, `got: ${JSON.stringify(result)}`);
+    assert.equal(JSON.parse(result.body).user.email, 'anon@getgrist.com');
+  });
+});

--- a/test/electron/setup.js
+++ b/test/electron/setup.js
@@ -1,0 +1,215 @@
+// Mocha --require plugin: launches the desktop Electron binary via
+// chromedriver, registers a WebDriver session with mocha-webdriver, connects
+// to grist-core's testing-hooks socket, and shapes upstream's test/nbrowser
+// `server` object so setupTestSuite() works without spawning anything.
+//
+// Spec: https://www.electronjs.org/docs/latest/tutorial/using-selenium-and-webdriver
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const http = require('http');
+const {Builder, Capabilities, Capability} = require('selenium-webdriver');
+const chrome = require('selenium-webdriver/chrome');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// Electron doesn't implement CDP's Browser domain, so chromedriver's
+// Browser.getWindowForTarget fails. Fall back to JS-side dimensions.
+const CDP_UNSUPPORTED = /getWindowForTarget|UnknownCommand/i;
+(function patchSeleniumWindowMethods() {
+  const Window = require('selenium-webdriver/lib/webdriver').Window;
+  const origGetRect = Window.prototype.getRect;
+  const origSetRect = Window.prototype.setRect;
+  Window.prototype.getRect = async function () {
+    try { return await origGetRect.call(this); }
+    catch (e) {
+      if (!CDP_UNSUPPORTED.test(String(e))) { throw e; }
+      return await this.driver_.executeScript(
+        'return {x:0,y:0,width:window.outerWidth,height:window.outerHeight}');
+    }
+  };
+  Window.prototype.setRect = async function (rect) {
+    try { return await origSetRect.call(this, rect); }
+    catch (e) {
+      if (!CDP_UNSUPPORTED.test(String(e))) { throw e; }
+      await this.driver_.executeScript(
+        `Object.defineProperty(window,'outerWidth',{configurable:true,value:${Number(rect.width)|0}});` +
+        `Object.defineProperty(window,'outerHeight',{configurable:true,value:${Number(rect.height)|0}});`);
+      return rect;
+    }
+  };
+})();
+
+const ELECTRON_BIN = path.join(REPO_ROOT, 'node_modules/electron/dist/electron');
+const CHROMEDRIVER_BIN = path.join(REPO_ROOT, 'node_modules/chromedriver/lib/chromedriver/chromedriver');
+const APP_ENTRY = path.join(REPO_ROOT, 'core/_build/ext/app/electron/main.js');
+
+const PORT = parseInt(process.env.GRIST_PORT || '8585', 10);
+
+// Set GRIST_TESTING_SOCKET so the desktop server creates the hook socket on
+// startup; we connect to it from the test process below. Deliberately *not*
+// setting HOME_URL — that flips upstream into "external server" mode, which
+// drives login via HTTP form instead of testingHooks.
+const TESTING_SOCKET = path.join(os.tmpdir(), `grist-desktop-testing-${process.pid}.sock`);
+process.env.GRIST_TESTING_SOCKET = TESTING_SOCKET;
+process.env.GRIST_DESKTOP_TEST_MODE = '1';
+process.env.GRIST_PORT = String(PORT);
+process.env.GRIST_SESSION_COOKIE = process.env.GRIST_SESSION_COOKIE || 'grist_test_cookie';
+process.env.GRIST_DESKTOP_AUTH = process.env.GRIST_DESKTOP_AUTH || 'none';
+process.env.GRIST_SANDBOX_FLAVOR = process.env.GRIST_SANDBOX_FLAVOR || 'unsandboxed';
+process.env.GRIST_FORCE_LOGIN = process.env.GRIST_FORCE_LOGIN || 'false';
+process.env.TEST_ACCOUNT_PASSWORD = process.env.TEST_ACCOUNT_PASSWORD || 'not-needed';
+// Seeds the support user's API key — see addSupportUserIfPossible.
+process.env.TEST_SUPPORT_API_KEY = process.env.TEST_SUPPORT_API_KEY || 'api_key_for_support';
+
+const mw = require('mocha-webdriver');
+
+let _tmpDir = null;
+let _logFd = null;
+
+function ensureBinariesExist() {
+  for (const [label, p] of [['electron', ELECTRON_BIN],
+                             ['chromedriver', CHROMEDRIVER_BIN],
+                             ['app entry', APP_ENTRY]]) {
+    if (!fs.existsSync(p)) { throw new Error(`${label} not found at ${p}; run yarn build`); }
+  }
+}
+
+async function ensurePortFree(port) {
+  await new Promise((resolve, reject) => {
+    const probe = http.get(`http://localhost:${port}/`, (res) => {
+      res.resume();
+      reject(new Error(`port ${port} is already serving HTTP — set GRIST_PORT to a free port`));
+    });
+    probe.on('error', () => resolve());      // ECONNREFUSED → free
+    probe.setTimeout(500, () => { probe.destroy(); resolve(); });
+  });
+}
+
+function makeTempDir() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'grist-desktop-test-'));
+  process.env.GRIST_INST_DIR = path.join(tmp, 'inst');
+  process.env.GRIST_DATA_DIR = path.join(tmp, 'docs');
+  process.env.TYPEORM_DATABASE = path.join(tmp, 'landing.db');
+  fs.mkdirSync(process.env.GRIST_INST_DIR, {recursive: true});
+  fs.mkdirSync(process.env.GRIST_DATA_DIR, {recursive: true});
+  return tmp;
+}
+
+async function waitForServer(baseUrl, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ok = await new Promise((resolve) => {
+      const req = http.get(`${baseUrl}/status`, (res) => {
+        res.resume(); resolve(res.statusCode === 200);
+      });
+      req.on('error', () => resolve(false));
+      req.setTimeout(1000, () => { req.destroy(); resolve(false); });
+    });
+    if (ok) { return; }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error(`Grist server did not respond at ${baseUrl}/status within ${timeoutMs}ms`);
+}
+
+async function startDriver() {
+  ensureBinariesExist();
+  await ensurePortFree(PORT);
+  _tmpDir = makeTempDir();
+
+  const opts = new chrome.Options();
+  opts.setChromeBinaryPath(ELECTRON_BIN);
+  // Don't block navigation on unhandled JS dialogs / beforeunload prompts.
+  opts.set(Capability.UNHANDLED_PROMPT_BEHAVIOR, {
+    alert: 'ignore', beforeUnload: 'ignore', confirm: 'ignore',
+    default: 'ignore', file: 'ignore', prompt: 'ignore',
+  });
+  const electronArgs = [`app=${APP_ENTRY}`, '--no-sandbox'];
+  // Force X11 to use Xvfb DISPLAY rather than the host's Wayland session.
+  if (process.platform === 'linux') { electronArgs.push('--ozone-platform=x11'); }
+  opts.addArguments(...electronArgs);
+
+  _logFd = fs.openSync(path.join(_tmpDir, 'chromedriver.log'), 'a');
+  const service = new chrome.ServiceBuilder(CHROMEDRIVER_BIN)
+    .addArguments('--disable-build-check')
+    .addArguments('--verbose');
+  service.setStdio(['ignore', _logFd, _logFd]);
+  console.log(`[setup] chromedriver log: ${path.join(_tmpDir, 'chromedriver.log')}`);
+
+  const driver = await new Builder()
+    .forBrowser('chrome')
+    .withCapabilities(Capabilities.chrome())
+    .setChromeOptions(opts)
+    .setChromeService(service)
+    .build();
+
+  mw.setDriver(driver);
+  await waitForServer(`http://localhost:${PORT}`);
+  // Only the borrowed Grist test suites need this extra setup. The desktop's
+  // own checks (Smoke, Probe) just open the app and look at it, so we skip it
+  // for them — which also lets them run without first building Grist's tests.
+  if (process.env.GRIST_DESKTOP_TEST_UPSTREAM === '1') {
+    await wireUpstreamTestServer();
+  }
+  return driver;
+}
+
+// Shape upstream's `server` object so `useServer(server)` and the various
+// HomeUtil/gristUtils helpers find what they expect — testingHooks for
+// login, database file path for support-user seeding, no-op lifecycle
+// hooks since Electron is the server.
+async function wireUpstreamTestServer() {
+  const {connectTestingHooks} = require('app/server/lib/TestingHooks');
+  const {server} = require('test/nbrowser/testServer');
+  await waitForSocket(TESTING_SOCKET, 15_000);
+  const hooks = await connectTestingHooks(TESTING_SOCKET);
+  server.testingHooks = hooks;
+  server.getTestingHooks = async () => hooks;
+  server.getHost = () => `http://localhost:${PORT}`;
+  server.isExternalServer = () => false;
+  server._getDatabaseFile = () => process.env.TYPEORM_DATABASE;
+  server.start = async () => {};
+  server.stop = async () => {};
+  server.resume = () => {};
+  server.closeDatabase = async () => { server._dbManager = undefined; };
+  return server;
+}
+
+async function waitForSocket(socketPath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) { return; }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error(`testing-hooks socket never appeared at ${socketPath}; ` +
+    `did GristApp.addTestingHooks run?`);
+}
+
+async function stopDriver() {
+  const driver = mw.setDriver(undefined);
+  if (driver) {
+    try { await driver.quit(); }
+    catch (e) { console.warn('driver.quit failed:', e.message || e); }
+  }
+  if (_logFd !== null) {
+    try { fs.closeSync(_logFd); }
+    catch (e) { console.warn('closeSync(logFd) failed:', e.message || e); }
+    _logFd = null;
+  }
+  if (_tmpDir && !process.env.KEEP_TMPDIR) {
+    fs.rmSync(_tmpDir, {recursive: true, force: true});
+  }
+  _tmpDir = null;
+}
+
+exports.mochaHooks = {
+  beforeAll: [async function () {
+    this.timeout(60_000);
+    await startDriver();
+  }],
+  afterAll: [async function () {
+    this.timeout(15_000);
+    await stopDriver();
+  }],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,7 +1857,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testim/chrome-version@^1.1.3":
+"@testim/chrome-version@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"
   integrity sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==
@@ -3736,14 +3736,14 @@ axios@1.16.0:
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
-axios@^1.2.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.13.5:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 b4a@^1.6.4:
   version "1.6.6"
@@ -4617,18 +4617,18 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz#05bffd7ff928465093314708c93bdfa9bd1f0f5b"
   integrity sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==
 
-chromedriver@110.0.0:
-  version "110.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-110.0.0.tgz#d00a1a2976592d933faa8e9839e97692922834a4"
-  integrity sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==
+chromedriver@146:
+  version "146.0.6"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-146.0.6.tgz#8c5e726b3d690a0879d5d3db9a963707777fc178"
+  integrity sha512-FIRi3hy0nRiyirK03etVXEpYTIodevFcvTBAM5ZCq+pX3w31jLm6JE8BVW1ypAVLvSp6HJDvboCcdgUroS3miw==
   dependencies:
-    "@testim/chrome-version" "^1.1.3"
-    axios "^1.2.1"
-    compare-versions "^5.0.1"
+    "@testim/chrome-version" "^1.1.4"
+    axios "^1.13.5"
+    compare-versions "^6.1.0"
     extract-zip "^2.0.1"
-    https-proxy-agent "^5.0.1"
-    proxy-from-env "^1.1.0"
-    tcp-port-used "^1.0.1"
+    proxy-agent "^6.5.0"
+    proxy-from-env "^2.0.0"
+    tcp-port-used "^1.0.2"
 
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
@@ -4873,10 +4873,10 @@ compare-version@^0.1.2:
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
 
-compare-versions@^5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.3.tgz#a9b34fea217472650ef4a2651d905f42c28ebfd7"
-  integrity sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==
+compare-versions@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
 
 components-jqueryui@1.12.1:
   version "1.12.1"
@@ -6860,10 +6860,15 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 follow-redirects@^1.16.0:
   version "1.16.0"
@@ -10570,7 +10575,7 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-agent@6.5.0:
+proxy-agent@6.5.0, proxy-agent@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.5.0.tgz#9e49acba8e4ee234aacb539f89ed9c23d02f232d"
   integrity sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==
@@ -10589,7 +10594,7 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-proxy-from-env@^2.1.0:
+proxy-from-env@^2.0.0, proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
@@ -12234,7 +12239,7 @@ tar@^7.5.10, tar@^7.5.4:
     minizlib "^3.1.0"
     yallist "^5.0.0"
 
-tcp-port-used@^1.0.1:
+tcp-port-used@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
   integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==


### PR DESCRIPTION
The desktop app now gets exercised by the some of the same WebDriver browser tests Grist uses, so we have a chance of catching regressions here before they reach anyone.

A new runner, scripts/test-electron.js, launches the packaged Electron binary through chromedriver and drives it headless. It has two modes: a quick local pass over the desktop-only checks, and an --upstream mode that points Grist's own nbrowser suites at the desktop build instead of the regular app.

CI picks all this up: after the build it runs the quick tests first so simple breakage fails fast, then compiles the core suites (build:tests) and runs 13 of them against the desktop app. The 13 are just a random set that happen not to exercise multi-user behavior.

More useful will be tests of Desktop-specific behavior obviously! This is just a starting point.