### PR TITLE
Fix packaging build failure under --ignore-optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
           architecture: ${{ matrix.host }}
 
       - name: Install dependencies
-        run: yarn install --network-timeout 300000
+        # Match the Packaging workflow, which skips optional dependencies
+        # because they add msgextract which fails on windows. Installing them
+        # here would hide packaging-only build failures.
+        run: yarn install --network-timeout 300000 --ignore-optional
 
       - name: Check version consistency
         run: node ./scripts/check-metainfo-version-matches.js

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     ]
   },
   "devDependencies": {
+    "@types/trusted-types": "2.0.7",
     "fast-xml-parser": "^5.7.3",
     "resolve-tspaths": "^0.8.19",
     "typescript": "4.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,7 +2603,7 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/trusted-types@^2.0.7":
+"@types/trusted-types@2.0.7", "@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==


### PR DESCRIPTION
dompurify declares @types/trusted-types as an optionalDependency, so Packaging's --ignore-optional install dropped it. Without its global Window augmentation, core's test/client/lib/sanitizeUrl.ts stops compiling (TS2345: DOMWindow vs WindowLike), which broke packaging on every platform while CI, installing optional deps, stayed green.