### PR TITLE
Fix the Electron browser tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "electron:ci": "./scripts/ci.sh",
     "electron": "electron-builder build --publish never",
     "test": "./scripts/smoke-test.sh && yarn run test:electron",
-    "test:electron": "./scripts/test-electron.js",
-    "test:electron:upstream": "./scripts/test-electron.js --upstream"
+    "test:electron": "node ./scripts/test-electron.js",
+    "test:electron:upstream": "node ./scripts/test-electron.js --upstream"
   },
   "resolutions": {
     "jquery": "3.5.0",

--- a/scripts/test-electron.js
+++ b/scripts/test-electron.js
@@ -53,10 +53,8 @@ function resolveTestFiles(mode, names) {
 }
 
 function checkPrereqs() {
-  const mochaBin = path.join(ROOT, 'core/node_modules/.bin', process.platform === 'win32' ? 'mocha.cmd' : 'mocha');
-  if (!fs.existsSync(mochaBin)) {
-    throw new Error(`mocha not found at ${mochaBin}; run yarn install first`);
-  }
+  // Not the .bin shim: it is a .cmd on Windows, and spawning that throws EINVAL.
+  const mochaBin = require.resolve('mocha/bin/mocha.js', {paths: [path.join(ROOT, 'core'), ROOT]});
   const appEntry = path.join(ROOT, 'core/_build/ext/app/electron/main.js');
   if (!fs.existsSync(appEntry)) {
     throw new Error('build output missing; run yarn build first');
@@ -118,7 +116,8 @@ function main() {
     '--require', path.join(ROOT, 'test/electron/setup.js'),
     ...testFiles,
   ];
-  const child = spawn(mochaBin, args, {stdio: 'inherit', cwd: ROOT, env: buildEnv(mode)});
+  const child = spawn(process.execPath, [mochaBin, ...args],
+    {stdio: 'inherit', cwd: ROOT, env: buildEnv(mode)});
   child.on('exit', code => process.exit(code ?? 1));
 }
 

--- a/test/electron/setup.js
+++ b/test/electron/setup.js
@@ -9,6 +9,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
+const net = require('net');
 const {Builder, Capabilities, Capability} = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 
@@ -51,7 +52,12 @@ const PORT = parseInt(process.env.GRIST_PORT || '8585', 10);
 // startup; we connect to it from the test process below. Deliberately *not*
 // setting HOME_URL — that flips upstream into "external server" mode, which
 // drives login via HTTP form instead of testingHooks.
-const TESTING_SOCKET = path.join(os.tmpdir(), `grist-desktop-testing-${process.pid}.sock`);
+// Windows binds a named pipe, not a socket file. The app awaits
+// addTestingHooks() before creating its window, so a failed bind here is silent:
+// the server runs, with no window for chromedriver to attach to.
+const TESTING_SOCKET = process.platform === 'win32'
+  ? `\\\\.\\pipe\\grist-desktop-testing-${process.pid}`
+  : path.join(os.tmpdir(), `grist-desktop-testing-${process.pid}.sock`);
 process.env.GRIST_TESTING_SOCKET = TESTING_SOCKET;
 process.env.GRIST_DESKTOP_TEST_MODE = '1';
 process.env.GRIST_PORT = String(PORT);
@@ -172,14 +178,19 @@ async function wireUpstreamTestServer() {
   server.start = async () => {};
   server.stop = async () => {};
   server.resume = () => {};
-  server.closeDatabase = async () => { server._dbManager = undefined; };
   return server;
 }
 
 async function waitForSocket(socketPath, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (fs.existsSync(socketPath)) { return; }
+    // Connect rather than stat: a named pipe has no filesystem entry.
+    const connected = await new Promise((resolve) => {
+      const sock = net.connect(socketPath)
+        .on('connect', () => { sock.destroy(); resolve(true); })
+        .on('error', () => resolve(false));
+    });
+    if (connected) { return; }
     await new Promise(r => setTimeout(r, 250));
   }
   throw new Error(`testing-hooks socket never appeared at ${socketPath}; ` +


### PR DESCRIPTION
Thetests had never run on windows: ci.yml is ubuntu-only, and packaging first ran them at the v0.3.14 tag, where they hung.

- package.json ran the .js directly; cmd hands .js to Windows Script Host, which hangs forever. Run it under node.
- test-electron.js spawned mocha.cmd, which throws EINVAL.
- GRIST_TESTING_SOCKET was a .sock path, but Windows binds named pipes. The failed bind left the app windowless, so chromedriver gave up with "unable to discover open pages".
- Our shim stubbed out closeDatabase, leaking the home DB connection this process opens to seed the support user. Windows then could not remove the temp dir; Linux tolerates unlinking an open file.