### PR TITLE
Run CI on all four packaging platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
       - dev
-    tags:
-      - '*'
+env:
+  FORCE_COLOR: 1
 
 jobs:
   build:
@@ -16,23 +16,40 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - macos-15-intel
           - ubuntu-22.04
+          - windows-2022
         host:
           - x64
         target:
           - x64
         node:
           - 22
+        include:
+          - os: macos-14
+            host: arm64
+            target: arm64
+            node: 22
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
-      - uses: actions/checkout@v3
+      # yarn run test starts with a .sh script, which cmd cannot run unaided.
+      - name: Set up bash association
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          cmd /c assoc .sh=bashscript
+          cmd /c ftype bashscript="%ProgramFiles%\Git\bin\bash.exe" "%1"
+
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          architecture: ${{ matrix.host }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Install dependencies
         # Match the Packaging workflow, which skips optional dependencies
@@ -41,6 +58,7 @@ jobs:
         run: yarn install --network-timeout 300000 --ignore-optional
 
       - name: Check version consistency
+        if: startsWith(matrix.os, 'ubuntu')
         run: node ./scripts/check-metainfo-version-matches.js
 
       - name: Hooks and crooks
@@ -53,10 +71,12 @@ jobs:
         run: yarn run build
 
       - name: Test
+        timeout-minutes: 20
         run: yarn run test
 
       - name: Build core browser tests
         run: yarn run build:tests
 
       - name: Run core browser tests against the desktop app
+        timeout-minutes: 30
         run: yarn run test:electron:upstream

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,11 +56,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Submodule cleanup fix  # See https://github.com/actions/checkout/issues/358
-        run: |
-          git submodule foreach --recursive git clean -ffdx
-          git submodule foreach --recursive git reset --hard
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -103,6 +98,7 @@ jobs:
         run: yarn run build
 
       - name: Test
+        timeout-minutes: 20
         run: yarn run test
 
 

--- a/test/electron/setup.js
+++ b/test/electron/setup.js
@@ -69,6 +69,10 @@ process.env.TEST_ACCOUNT_PASSWORD = process.env.TEST_ACCOUNT_PASSWORD || 'not-ne
 // Seeds the support user's API key — see addSupportUserIfPossible.
 process.env.TEST_SUPPORT_API_KEY = process.env.TEST_SUPPORT_API_KEY || 'api_key_for_support';
 
+// Node's default agent has timeout: 5000, and on windows that kills a request
+// in flight. Opening a doc on a slow machine outlasts it.
+http.globalAgent = new http.Agent({keepAlive: true});
+
 const mw = require('mocha-webdriver');
 
 let _tmpDir = null;


### PR DESCRIPTION
CI was ubuntu-only, so windows and mac problems first showed up at a release tag. Match the packaging matrix.

Cap the test steps too, so a hang fails in minutes instead of running into the six hour default.

The two workflows had also drifted apart. Now reconciled.

A submodule hack only needed on self-hosted runners was removed.